### PR TITLE
fix: add iPhone 15/15Plus to iphonesStatusbarHeight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/helpers",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Builders helpers library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/native/iphoneHelper.ts
+++ b/src/native/iphoneHelper.ts
@@ -53,6 +53,8 @@ const iphonesStatusbarHeight = {
   'iPhone14,8': 47, // iPhone 14 Plus
   'iPhone15,2': 54, // iPhone 14 Pro
   'iPhone15,3': 54, // iPhone 14 Pro Max
+  'iPhone15,4': 54, // iPhone 15
+  'iPhone15,5': 54, // iPhone 15 Plus
   'iPhone16,1': 54, // iPhone 15 Pro
   'iPhone16,2': 54, // iPhone 15 Pro Max
 };


### PR DESCRIPTION
## Descrição do PR

Adicionado dois tipos de iPhone na lista iPhoneHeight para o tratamento correto para definir o tamanho da statusBar.

#Prints

### Antes

![Captura de Tela 2024-09-04 às 08 56 25](https://github.com/user-attachments/assets/7a99c605-88fe-4085-b034-cebc3174797b)

### Depois

![Captura de Tela 2024-09-04 às 08 56 32](https://github.com/user-attachments/assets/010ffd86-26a9-4375-a7a2-f08057f31a7f)

## Tipo de mudança

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)

## Checklist 🚨

- [x] Testado usando Yalc
- [x] Meu código segue o code style da Builders
- [ ] Meu código foi feito utilizando TDD (**testes unitários obrigatórios**)
