### PR TITLE
fix: add iPhone 16 family to iphonesStatusbarHeight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platformbuilders/helpers",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Builders helpers library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/native/iphoneHelper.ts
+++ b/src/native/iphoneHelper.ts
@@ -57,8 +57,8 @@ const iphonesStatusbarHeight = {
   'iPhone15,5': 54, // iPhone 15 Plus
   'iPhone16,1': 54, // iPhone 15 Pro
   'iPhone16,2': 54, // iPhone 15 Pro Max
-  'iPhone17,3': 52, // iPhone 16
-  'iPhone17,4': 52, // iPhone 16 Plus
-  'iPhone17,1': 52, // iPhone 16 Pro
-  'iPhone17,2': 52, // iPhone 16 Pro Max
+  'iPhone17,3': 54, // iPhone 16
+  'iPhone17,4': 54, // iPhone 16 Plus
+  'iPhone17,1': 54, // iPhone 16 Pro
+  'iPhone17,2': 54, // iPhone 16 Pro Max
 };

--- a/src/native/iphoneHelper.ts
+++ b/src/native/iphoneHelper.ts
@@ -57,4 +57,8 @@ const iphonesStatusbarHeight = {
   'iPhone15,5': 54, // iPhone 15 Plus
   'iPhone16,1': 54, // iPhone 15 Pro
   'iPhone16,2': 54, // iPhone 15 Pro Max
+  'iPhone17,3': 52, // iPhone 16
+  'iPhone17,4': 52, // iPhone 16 Plus
+  'iPhone17,1': 52, // iPhone 16 Pro
+  'iPhone17,2': 52, // iPhone 16 Pro Max
 };


### PR DESCRIPTION
## Descrição do PR

Adicionado 4 novos tipos de iPhone na lista iPhoneHeight para o tratamento correto para definir o tamanho da statusBar.

# Prints

### Antes

![Captura de Tela 2024-09-18 às 16 22 55](https://github.com/user-attachments/assets/20ba60c6-7310-48e2-8315-0546ba453e9b)

### Depois

![Captura de Tela 2024-09-18 às 16 21 26](https://github.com/user-attachments/assets/7f96eba9-01ac-4130-b9b7-6989b8ee4ec1)

## Tipo de mudança

- [ ] Nova feature (mudança non-breaking que adiciona uma funcionalidade)
- [x] Bug fix (mudança non-breaking que conserta um problema)
- [ ] Breaking change (ajuste ou funcionalidade que pode causar uma quebra numa funcionalidade já existente)
- [ ] Chore (nenhuma das anteriores, como upgrade de libs)

## Checklist 🚨

- [x] Testado usando Yalc
- [x] Meu código segue o code style da Builders
- [ ] Meu código foi feito utilizando TDD (**testes unitários obrigatórios**)
